### PR TITLE
Stop using /etc/pgbouncer.ini as ~zabbix/.pgpass is enough

### DIFF
--- a/files/pgbouncer/scripts/pgbouncer.pool.discovery.sh
+++ b/files/pgbouncer/scripts/pgbouncer.pool.discovery.sh
@@ -3,11 +3,11 @@
 # Description:	Pgbouncer pools auto-discovery
 
 if [ ! -f ~zabbix/.pgpass ]; then echo "ERROR: ~zabbix/.pgpass not found" ; exit 1; fi
-config='/etc/pgbouncer.ini'
-hostname=$(grep -w ^listen_addr $config |cut -d" " -f3 |cut -d, -f1)
-port=6432
-dbname="pgbouncer"
+
+hostname=$(head -n 1 ~zabbix/.pgpass |cut -d: -f1)
+port=$(head -n 1 ~zabbix/.pgpass |cut -d: -f2)
 username=$(head -n 1 ~zabbix/.pgpass |cut -d: -f4)
+dbname="pgbouncer"
 
 if [ '*' = "$hostname" ]; then hostname="127.0.0.1"; fi
 

--- a/files/pgbouncer/scripts/pgbouncer.stat.sh
+++ b/files/pgbouncer/scripts/pgbouncer.stat.sh
@@ -6,11 +6,11 @@
 if [ ! -f ~zabbix/.pgpass ]; then echo "ERROR: ~zabbix/.pgpass not found" ; exit 1; fi
 
 PSQL=$(which psql)
-config='/etc/pgbouncer.ini'
-hostname=$(grep -w ^listen_addr $config |cut -d" " -f3 |cut -d, -f1)
-port=6432
-dbname="pgbouncer"
+
+hostname=$(head -n 1 ~zabbix/.pgpass |cut -d: -f1)
+port=$(head -n 1 ~zabbix/.pgpass |cut -d: -f2)
 username=$(head -n 1 ~zabbix/.pgpass |cut -d: -f4)
+dbname="pgbouncer"
 PARAM="$1"
 
 if [ '*' = "$hostname" ]; then hostname="127.0.0.1"; fi


### PR DESCRIPTION
In some distribution (as Debian) the ini file is `/etc/pgbouncer/pgbouncer.ini` and is not readable by zabbix user, so I propose to only use the `.pgpass` file as it already read.
