### PR TITLE
equal names of pool and db

### DIFF
--- a/files/pgbouncer/scripts/pgbouncer.stat.sh
+++ b/files/pgbouncer/scripts/pgbouncer.stat.sh
@@ -31,28 +31,28 @@ case "$PARAM" in
         $PSQL $conn_param -c "show stats" |grep -w $2 |cut -d: -f9
 ;;
 'cl_active' )
-        $PSQL $conn_param -c "show pools" |grep -w $2 |cut -d: -f3
+        $PSQL $conn_param -c "show pools" |grep -w ^$2 |cut -d: -f3
 ;;
 'cl_waiting' )
-        $PSQL $conn_param -c "show pools" |grep -w $2 |cut -d: -f4
+        $PSQL $conn_param -c "show pools" |grep -w ^$2 |cut -d: -f4
 ;;
 'sv_active' )
-        $PSQL $conn_param -c "show pools" |grep -w $2 |cut -d: -f5
+        $PSQL $conn_param -c "show pools" |grep -w ^$2 |cut -d: -f5
 ;;
 'sv_idle' )
-        $PSQL $conn_param -c "show pools" |grep -w $2 |cut -d: -f6
+        $PSQL $conn_param -c "show pools" |grep -w ^$2 |cut -d: -f6
 ;;
 'sv_used' )
-        $PSQL $conn_param -c "show pools" |grep -w $2 |cut -d: -f7
+        $PSQL $conn_param -c "show pools" |grep -w ^$2 |cut -d: -f7
 ;;
 'sv_tested' )
-        $PSQL $conn_param -c "show pools" |grep -w $2 |cut -d: -f8
+        $PSQL $conn_param -c "show pools" |grep -w ^$2 |cut -d: -f8
 ;;
 'sv_login' )
-        $PSQL $conn_param -c "show pools" |grep -w $2 |cut -d: -f9
+        $PSQL $conn_param -c "show pools" |grep -w ^$2 |cut -d: -f9
 ;;
 'maxwait' )
-        $PSQL $conn_param -c "show pools" |grep -w $2 |cut -d: -f10
+        $PSQL $conn_param -c "show pools" |grep -w ^$2 |cut -d: -f10
 ;;
 'free_clients' )
         $PSQL $conn_param -c "show lists" |grep -w free_clients |cut -d: -f2


### PR DESCRIPTION
"show pools" command shows names of pools and databases. This may lead to problem, when this script returns several rows. Example:
```
sudo -u zabbix psql -qAtX -F: -h localhost -p6432 -U pgbouncer pgbouncer -c "show pools" | grep -w test
test:test:145:0:74:3:0:0:0:0
test_standby:test:75:0:71:3:0:0:0:0
```
I have 2 pools, that named "test" and "test_standby", and database that named "test".
If i will add ^ symbol to grep, it looks like the problem is resolved
```
sudo -u zabbix psql -qAtX -F: -h localhost -p6432 -U pgbouncer pgbouncer -c "show pools" | grep -w ^test
test:test:142:0:73:0:10:0:0:0
```