### PR TITLE
Fix for brick server when XFS mountpoints have "glusterfs" in

### DIFF
--- a/files/glusterfs-client/scripts/glusterfs.discovery.sh
+++ b/files/glusterfs-client/scripts/glusterfs.discovery.sh
@@ -2,7 +2,7 @@
 # Author:	Lesovsky A.V.
 # Description:	Glusterfs mounts auto-discovery
 
-mountpoints=$(grep glusterfs /etc/fstab |grep -v ^# |awk '{print $2}')
+mountpoints=$(egrep -e '\sglusterfs\s' /etc/fstab|grep -v ^# |awk '{print $2}')
 
 echo -n '{"data":['
 for mount in $mountpoints; do echo -n "{\"{#MOUNT}\": \"$mount\"},"; done |sed -e 's:\},$:\}:'


### PR DESCRIPTION
(example : /dev/sda /data/glusterfs/brick1 xfs ...)