### PR TITLE
Resolve compatibility issues.

### DIFF
--- a/files/postgresql/postgresql.conf
+++ b/files/postgresql/postgresql.conf
@@ -17,7 +17,7 @@ UserParameter=pgsql.buffercache.used[*],psql -qAtX $1 -c "select count(*) from p
 UserParameter=pgsql.buffercache.total[*],psql -qAtX $1 -c "select count(*) from pg_buffercache"
 
 # General info
-UserParameter=pgsql.ping[*],/bin/echo -e "\\\timing \n select 1" | psql -qAtX $1 |grep Time |cut -d' ' -f2
+UserParameter=pgsql.ping[*],/bin/echo -e "\\\timing \n select 1" | psql -qAtX $1 | tail -n 1 |cut -d' ' -f2
 UserParameter=pgsql.uptime[*],psql -qAtX $1 -c "select date_part('epoch', now() - pg_postmaster_start_time())::int"
 UserParameter=pgsql.cache.hit[*],psql -qAtX $1 -c "select round(sum(blks_hit)*100/sum(blks_hit+blks_read), 2) from pg_stat_database"
 


### PR DESCRIPTION
This grep condition works fine only if english locale is used. Tail method is much better since it isn't dependent on the messages locale.