### PR TITLE
Add NVMe device type support & Ability to collect data for Zabbix version 3.4+

### DIFF
--- a/files/iostat/crontab
+++ b/files/iostat/crontab
@@ -1,0 +1,2 @@
+# Collect data iops for zabbix
+* * * * * root /usr/libexec/zabbix-extensions/scripts/iostat-collect.sh /tmp/iostat.out 60

--- a/files/iostat/iostat-disk-utilization-template.xml
+++ b/files/iostat/iostat-disk-utilization-template.xml
@@ -91,7 +91,7 @@
                     <publickey/>
                     <privatekey/>
                     <port/>
-                    <filter>{#HARDDISK}:^(xvd|sd|hd|vd)[a-z]</filter>
+                    <filter>{#HARDDISK}:^((xvd|sd|hd|vd)[a-z]|(nvme[0-9]+n[0-9]+))</filter>
                     <lifetime>1</lifetime>
                     <description/>
                     <item_prototypes>

--- a/files/iostat/iostat.conf
+++ b/files/iostat/iostat.conf
@@ -1,5 +1,5 @@
 # Disk statistics via iostat (sysstat)
 # Attention: Second parameter in iostat.collect must be less than Timeout option in zabbix_agentd.conf
 UserParameter=iostat.discovery, iostat -d | awk 'BEGIN {check=0;count=0;array[0]=0;} {if(check==1 && $1 != ""){array[count]=$1;count=count+1;}if($1=="Device:"){check=1;}} END {printf("{\n\t\"data\":[\n");for(i=0;i<count;++i){printf("\t\t{\n\t\t\t\"{#HARDDISK}\":\"%s\"}", array[i]); if(i+1<count){printf(",\n");}} printf("]}\n");}'
-UserParameter=iostat.collect,/usr/libexec/zabbix-extensions/scripts/iostat-collect.sh /tmp/iostat.out 8 || echo 1
-UserParameter=iostat.metric[*],/usr/libexec/zabbix-extensions/scripts/iostat-parse.sh /tmp/iostat.out $1 $2
+UserParameter=iostat.collect, /usr/libexec/zabbix-extensions/scripts/iostat-collect.sh /tmp/iostat-non-cron.out 1 || echo 1
+UserParameter=iostat.metric[*], /usr/libexec/zabbix-extensions/scripts/iostat-parse.sh /tmp/iostat.out $1 $2


### PR DESCRIPTION
I try to collect data for NVMe device but it named as "/dev/nvme0n1". So discovery rules do not find my device for start save-use iops data. Fixed it for discovery rules.

New version of zabbix disallow to collect data over 1 minute. Just 5 seconds timeout. So we should have some cron script or deamon for collect data. So I have provide commit for solve this problem at last version of zabbix.