### PR TITLE
Fix small issues

### DIFF
--- a/files/hwraid-megacli/scripts/megacli-raid-data-processor.sh
+++ b/files/hwraid-megacli/scripts/megacli-raid-data-processor.sh
@@ -155,7 +155,7 @@ cat $all_keys | while read key; do
      enc=$(echo $key |grep -o '\[.*\]' |tr -d \[\] |cut -d: -f2)
      pd=$(echo $key |grep -o '\[.*\]' |tr -d \[\] |cut -d: -f3)
      value=$(sed -n -e "/pd begin $adp $enc $pd/,/ld end $adp $enc $pd/p" $data_out |grep -m1 -w "^Drive Temperature" |awk '{print $3}' |grep -oE '[0-9]+')
-     echo "\"$zbx_hostname\" $key $value" >> $zbx_data
+     echo "\"$zbx_hostname\" $key ${value:-0}" >> $zbx_data
   fi
   done
 

--- a/files/hwraid-smartarray/scripts/hp-raid-data-processor.sh
+++ b/files/hwraid-smartarray/scripts/hp-raid-data-processor.sh
@@ -19,7 +19,7 @@ fi
 data_tmp="/tmp/hp-raid-data-harvester.tmp"
 data_out="/tmp/hp-raid-data-harvester.out"
 all_keys='/tmp/keys'
-zbx_servers=$(grep ^Server\= /etc/zabbix/zabbix_agentd.conf |cut -d= -f2|sed 's/,/ /')
+zbx_servers=$(grep ^Server\= /etc/zabbix/zabbix_agentd.conf |cut -d= -f2|sed 's/,/ /g')
 zbx_hostname=$(grep ^Hostname\= /etc/zabbix/zabbix_agentd.conf |cut -d= -f2|cut -d, -f1)
 zbx_data='/tmp/zabbix-sender-hp-raid-data.in'
 ctrl_list=$(${hpcli} ctrl all show |grep -oE 'Slot [0-9]+' |awk '{print $2}' |xargs echo)

--- a/files/linux/scripts/check-netif-speed.sh
+++ b/files/linux/scripts/check-netif-speed.sh
@@ -22,10 +22,15 @@ MODE=$1
 case "$MODE" in
 '--discovery' )
 	printf "{\n";
-	printf "\t\"data\":[\n\n";
+	printf "\t\"data\":[\n";
+	INDEX=0
 	for interface in ${physActiveIfList}
 	do
-		printf "\t{\n";
+		if [ $INDEX -gt 0 ]
+		then
+			printf ",";
+		fi
+		printf "\n\t{\n";
 		printf "\t\t\"{#PHYS_IFNAME}\":\"$interface\"\n";
 		printf "\t},\n";
 	done


### PR DESCRIPTION
Fix. Sometimes megacli return empty temperature (Drive Temperature : N/A)
Fix. The script check-netif-speed.sh return invalid JSON (Removed the last comma)
Fix. The script hp-raid-data-processor.sh incorrect parse the servers variable from zabbix agent config