### PR TITLE
make script compatible also with pgsql 10+

### DIFF
--- a/files/postgresql/postgresql.conf
+++ b/files/postgresql/postgresql.conf
@@ -96,8 +96,8 @@ UserParameter=pgsql.table.stat.autoanalyze_count[*],psql -qAtX $1 -c "select coa
 # Streaming replication
 UserParameter=pgsql.streaming.count[*],psql -qAtX $1 -c "select count(*) from pg_stat_replication"
 UserParameter=pgsql.streaming.state[*],psql -qAtX $1 -c "select pg_is_in_recovery()"
-UserParameter=pgsql.streaming.lag.bytes[*],psql -qAtX $1 -c "select greatest(0,pg_xlog_location_diff(pg_current_xlog_location(), replay_location)) from pg_stat_replication where client_addr = '$2'"
-UserParameter=pgsql.streaming.lag.seconds[*],psql -qAtX -h $2 $1 -c "SELECT CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0 ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()) END"
+UserParameter=pgsql.streaming.lag.bytes[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "100000" ]; then psql -qAtX $1 -c "select greatest(0,pg_wal_lsn_diff(pg_current_wal_lst(), replay_lsn)) from pg_stat_replication where client_addr = '$2'"; else psql -qAtX $1 -c "select greatest(0,pg_xlog_location_diff(pg_current_xlog_location(), replay_location)) from pg_stat_replication where client_addr = '$2'"; fi
+UserParameter=pgsql.streaming.lag.seconds[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "100000" ]; then psql -qAtX -h $2 $1 -c "SELECT CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0 ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()) END"; else psql -qAtX -h $2 $1 -c "SELECT CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0 ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()) END"; fi
 
 # Transactions
 UserParameter=pgsql.transactions.idle[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where state='idle in transaction'"
@@ -112,8 +112,8 @@ UserParameter=pgsql.pgstatstatements.avg_query_time[*],psql -qAtX $1 -c "select 
 UserParameter=pgsql.table.tuples[*],psql -qAtX $1 -c "select count(*) from $2"
 UserParameter=pgsql.setting[*],psql -qAtX $1 -c "select current_setting('$2')"
 UserParameter=pgsql.trigger[*],psql -qAtX $1 -c "select count(*) from pg_trigger where tgenabled='O' and tgname='$2'"
-UserParameter=pgsql.wal.write[*],psql -qAtX $1 -c "select pg_xlog_location_diff(pg_current_xlog_location(),'0/00000000')"
-UserParameter=pgsql.wal.count[*],psql -qAtX $1 -c "select count(*) from pg_ls_dir('pg_xlog')"
+UserParameter=pgsql.wal.write[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "100000" ]; then psql -qAtX $1 -c "select pg_wal_lsn_diff(pg_current_wal_lsn(),'0/00000000')"; else psql -qAtX $1 -c "select pg_xlog_location_diff(pg_current_xlog_location(),'0/00000000')"; fi
+UserParameter=pgsql.wal.count[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "100000" ]; then psql -qAtX $1 -c "select count(*) from pg_ls_waldir()"; else psql -qAtX $1 -c "select count(*) from pg_ls_dir('pg_xlog')"; fi
 
 # Discovery
 UserParameter=pgsql.db.discovery[*],/bin/echo -n '{"data":['; for db in $(psql -qAtX $1 -c "select datname from pg_database where not datistemplate and datallowconn and datname!='postgres'"); do /bin/echo -n "{\"{#DBNAME}\": \"$db\"},"; done |sed -e 's:,$::'; /bin/echo -n ']}'


### PR DESCRIPTION
PostgreSQL version 10 renamed some functions. As I found no way to solve this in pure SQL I wrapped the calls on the shell. Should still be low overhead enough to cause no problems. I will use the new names for versions 10 and newer.

This fixes #42 