### PR TITLE
postgresql: minimum supported version is 9.4

### DIFF
--- a/files/postgresql/README.md
+++ b/files/postgresql/README.md
@@ -15,7 +15,7 @@ It is a set of `UserParameter` for PostgreSQL monitoring, which consists of Zabb
 - low level discovery for streaming standby servers, databases, tables
 
 ## Supported versions
-- PostgreSQL version 9.3 and above
+- PostgreSQL version 9.4 and above
 - Zabbix 3.4 and newer
 
 ## Short how-to install and configure


### PR DESCRIPTION
PostgreSQL supports only 9.4 upwards, so no need to keep the burden with 9.3 support