### PR TITLE
fix compatibility with PostgreSQL 9.5 and below

### DIFF
--- a/files/postgresql/postgresql.conf
+++ b/files/postgresql/postgresql.conf
@@ -10,7 +10,7 @@ UserParameter=pgsql.uptime[*],psql -qAtX $1 -c "select date_part('epoch', now() 
 UserParameter=pgsql.cache.hit[*],psql -qAtX $1 -c "select round(sum(blks_hit)*100/sum(blks_hit+blks_read), 2) from pg_stat_database"
 
 # Connections
-UserParameter=pgsql.connections[*],psql -qAtX $1 -c "SELECT row_to_json(j) FROM (select sum(CASE WHEN state = 'active' THEN 1 ELSE 0 END) AS active, sum(CASE WHEN state = 'idle' THEN 1 ELSE 0 END) AS idle, sum(CASE WHEN state = 'idle in transaction' THEN 1 ELSE 0 END) AS idle_in_transaction, count(*) AS total, count(*)*100/(select current_setting('max_connections')::int) AS total_pct, sum(CASE WHEN wait_event is not null THEN 1 ELSE 0 END) AS waiting from pg_stat_activity) AS j"
+UserParameter=pgsql.connections[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "090600" ]; then psql -qAtX $1 -c "SELECT row_to_json(j) FROM (select sum(CASE WHEN state = 'active' THEN 1 ELSE 0 END) AS active, sum(CASE WHEN state = 'idle' THEN 1 ELSE 0 END) AS idle, sum(CASE WHEN state = 'idle in transaction' THEN 1 ELSE 0 END) AS idle_in_transaction, count(*) AS total, count(*)*100/(select current_setting('max_connections')::int) AS total_pct, sum(CASE WHEN wait_event is not null THEN 1 ELSE 0 END) AS waiting from pg_stat_activity) AS j"; else psql -qAtX $1 -c "SELECT row_to_json(j) FROM (select sum(CASE WHEN state = 'active' THEN 1 ELSE 0 END) AS active, sum(CASE WHEN state = 'idle' THEN 1 ELSE 0 END) AS idle, sum(CASE WHEN state = 'idle in transaction' THEN 1 ELSE 0 END) AS idle_in_transaction, count(*) AS total, count(*)*100/(select current_setting('max_connections')::int) AS total_pct, sum(CASE WHEN waiting IS TRUE THEN 1 ELSE 0 END) AS waiting from pg_stat_activity) AS j"; fi
 UserParameter=pgsql.connections.prepared[*],psql -qAtX $1 -c "select count(*) from pg_prepared_xacts"
 
 # Size of database, table or indexes of specified table
@@ -72,7 +72,7 @@ UserParameter=pgsql.streaming.lag.seconds[*],if [ "$(psql -qAtX $1 -c 'show serv
 # Transactions
 UserParameter=pgsql.transactions.idle[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where state='idle in transaction'"
 UserParameter=pgsql.transactions.active[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where state <> 'idle in transaction' and state <> 'idle'"
-UserParameter=pgsql.transactions.waiting[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where wait_event is not null"
+UserParameter=pgsql.transactions.waiting[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "090600" ]; then psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where wait_event is not null"; else psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where waiting IS TRUE"; fi
 UserParameter=pgsql.transactions.prepared[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), prepared))), 0) from pg_prepared_xacts"
 
 # pg_stat_statements


### PR DESCRIPTION
PostgreSQL 9.6 removed column waiting from pg_stat_activity. This makes it necessary to distinguish the versions when fetching data.

fixes #58