### PR TITLE
Update iostat-collect.sh

### DIFF
--- a/files/iostat/scripts/iostat-collect.sh
+++ b/files/iostat/scripts/iostat-collect.sh
@@ -12,6 +12,6 @@ LC_ALL=C ; export LC_ALL
 
 [[ $# -lt 2 ]] && { echo "FATAL: some parameters not specified"; exit 1; }
 
-DISK=$($IOSTAT -x 1 "$SECONDS" | awk 'BEGIN {check=0;} {if(check==1 && $1=="avg-cpu:"){check=0}if(check==1 && $1!=""){print $0}if($1=="Device:"){check=1}}' | tr '\n' '|')
+DISK=$($IOSTAT -x "$SECONDS" 2 | awk 'BEGIN {check=0;} {if(check==1 && $1=="avg-cpu:"){check=0}if(check==1 && $1!=""){print $0}if($1=="Device:"){check=1}}' | tr '\n' '|')
 echo "$DISK" | sed 's/|/\n/g' > "$TOFILE"
 echo 0


### PR DESCRIPTION
hello! I saw errors in file iostat-collect.sh: iostat man tels, that right order of options is "interval" and "count", not "count" and "interval". For delta statistic in N seconds it must be set count = 2, not count = 1 (in that wat it will be mean statistic since reboot). I hope this changes will be useful :) Thanks for great article on habr!