### PR TITLE
Update crontab

### DIFF
--- a/files/iostat/crontab
+++ b/files/iostat/crontab
@@ -1,2 +1,2 @@
 # Collect data iops for zabbix
-* * * * * root /usr/libexec/zabbix-extensions/scripts/iostat-collect.sh /tmp/iostat.out 60
+* * * * * /usr/libexec/zabbix-extensions/scripts/iostat-collect.sh /tmp/iostat-cron.out 55 #>/dev/null 2>&1


### PR DESCRIPTION
No need to type "root" in crontab in modern linux systems. Cront task period is 1 minute, so if collect script will refresh in the same time, it can be strange behavior for next call (which value will be read by zabbix agent - older or newer?). I recommend to set 55 secods period for collect script to avoid collisions. Name of output file is iostat-cron.out - for follow logic in iostat.conf (parameter iostat.collect is output in iostat-non-cron.out file). Optionality result of running cron task may be redirected in dev/null for avoid root user reciving mails every minute (this option may use only after make sure, that scron task is correct and executing every minute).