### PR TITLE
Cuted down unused autovacuum monitoring

### DIFF
--- a/files/postgresql/postgresql.conf
+++ b/files/postgresql/postgresql.conf
@@ -71,7 +71,7 @@ UserParameter=pgsql.streaming.lag.seconds[*],if [ "$(psql -qAtX $1 -c 'show serv
 
 # Transactions
 UserParameter=pgsql.transactions.idle[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where state='idle in transaction'"
-UserParameter=pgsql.transactions.active[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where state <> 'idle in transaction' and state <> 'idle'"
+UserParameter=pgsql.transactions.active[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where state <> 'idle in transaction' and state <> 'idle' and query NOT LIKE 'autovacuum%'"
 UserParameter=pgsql.transactions.waiting[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "090600" ]; then psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where wait_event is not null"; else psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where waiting IS TRUE"; fi
 UserParameter=pgsql.transactions.prepared[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), prepared))), 0) from pg_prepared_xacts"
 


### PR DESCRIPTION
Results from transactions monitoring are also including autovacuum queries during checks, this fix will cut them down. Let me show few examples of running check queries at real database:
1. `psql -U postgres -t -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) as exec_time, query from pg_stat_activity where state <> 'idle in transaction' and state <> 'idle' group by query order by exec_time desc" `, it will show us all running transactions, which is not in idle state in this output: quert_execution_time, query
```
 1950.319903 | VACUUM (ANALYZE);
 1500.462969 | autovacuum: VACUUM public.orders (to prevent wraparound)
    0.770166 | \r                                                                                                                                                                                                            +
             |         SELECT \r                                                                                                                                                                                             +
             |             orders.order_id, \r                                                                                                                                                                               +
             |             orders.service_id, \r                                                                                                                                                                             +
             |             service_types.service_short_name, \r                                                                                                                                                              +
             |             format(\r                                                                                                                                                                                         +
             |                 '<b>%s%s</b>%s',\r                                                                                                                                                                            +
             |                 CASE WHEN NOT vcwc.is_account THEN '<i class="icon-shopping-cart" title="Non Account"></i> ' END,\r                                                                                           +
             |                 vcwc.customer_name_iconed,\r                                                                                                                                                                  +
             |                 ', ' ||\r                                                                                                                                                                                     +
             |                 CASE WHEN address_coordinates2.lat IS NULL THEN \r                                                                                                                                            +
             |                     vcwc.full_address_iconed || ' <a href="/system/address&customer_address_id=' \r                                                                                                           +
             |                         || vcwc.customer_address_id || '" title="Set coordinates" target="_blank">'\r                                                                                                         +
             |                         || '<i class="icon-map-marker"></i></a>'\r                                                                                                                                            +
             |                 ELSE \r                                                                                                                                                                                       +
             |                     '<a href="/system/address&customer_address_id=' || vcwc.customer_address_id || '" '\r                                                                                                     +
             |                         || 'target="_blank"><i class="icon-map-marker"></i> ' || vcwc.full_address_iconed || '</a>'\r                                                                                         +
             |                 END\r                                                                                                                                                                                         +
             |             ) as name_and_address,\r                                                                                                                                                                          +
             |             order_weights.weight_gross, \r                                                                                                                                                                    +
             |             order_weights.weight_tare, \r                                                                                                                                                                     +
             |             order_weights.weight_ticket, \r                                                                                                                                                                   +
             |             grade, \r                                                                                                                                                                                         +
             |             grade_id, \r                                                                                                                                                                                      +
             |             orders.tip_id,\r                                                                                                                                                                                  +
             |                 \r                                                                                                                                                                                            +
             |                 CASE WHEN address_coordinates.lat IS NULL THEN \r                                                                                                                                             +
             |                 '<b>' || vcwc_tip.tip_name_iconed || '</b>, ' || vcwc_tip.tip_address_iconed \r                                                                                                               +
             |                     || ' <a href="/system/address&customer_address_id=' || vcwc_tip.customer_address_id || '" '\r                                                                                             +
             |                     || 'title="Set coordinates" target="_blank"><i class="icon-map-marker"></i></a>'\r                                                                                                        +
             |             ELSE \r                                                                                                                                                                                           +
             |                 '<a href="/system/address&customer_address_id=' || vcwc_tip.customer_address_id \r                                                                                                            +
             |                     || '" target="_blank"><i class="icon-map-marker"></i> ' || '<b>' || vcwc_tip.tip_name_iconed || '</b>, ' \r                                                                               +
             |                     || vcwc_tip.tip_address_iconed || '</a>'\r                                                                                                                                                +
             |             END as tip,\r                                                                                                                                                                                     +
             | \r                                                                                                                                                                                                            +
             | \r                                                                                                                                                                                                            +
             |                 driversheets.order_id, \r                                                                                                                                                                     +
             |                 vehicle_id, \r                                                                                                                                                                                +
             |                 job_order, \r                                                                                                                                                                                 +
             |                 reg_number, \r                                                                                                                                                                                +
             |                 cb.container as con
    0.001189 |                                                                                                                                                                                                               +
             |         WITH more_??_invoice_lines as (                                                                                                                                                                      +
             |             SELECT count(*), invoice_id                                                                                                                                                                       +
             |             FROM invoice_lines                                                                                                                                                                                +
             |             GROUP BY invoice_id                                                                                                                                                                               +
             |             HAVING count(*) >= ???                                                                                                                                                                        +
             |             ORDER BY count DESC                                                                                                                                                                               +
             |         )                                                                                                                                                                                                     +
             |         SELECT DISTINCT                                                                                                                                                                                       +
             |                                                                                                                                                                                                               +
             |             invoice_start,                                                                                                                                                                                    +
             |             is_closed,                                                                                                                                                                                        +
             |             a.is_exported,                                                                                                                                                                                    +
             |             cn.is_exported as notes_is_exported,                                                                                                                                                              +
             |             orders.customer_id,                                                                                                                                                                               +
             |             a.in_advance,                                                                                                                                                                                     +
             |             a.invoice_line_id,                                                                                                                                                                                +
             |             a.self_bill,                                                                                                                                                                                      +
             |                                                                                                                                                                                                               +
             |             CASE WHEN service_id IN (????)                                                                                                                                           +
             |                 THEN                                                                                                                                                                                          +
             |                     CASE WHEN a.in_advance IS TRUE                                                                                                                                                            +
             |                     THEN actual_quantity || ' (<b>' || quantity || '</b>)'           

```
As you can see the most slow transaction is autovacuum, whcih runs for over ~2000 second, or 33 minutes, but those results are not real. Autovacuum is system function and i think it's not the best decision to monitor it

2. Query from script returns us the value of avutovacuum
```
[root@zabbix ~]# zabbix_get -s ???.???.???.??? -k pgsql.transactions.active[*]
 3351.53421
```

3. After fix we are getting real values of query's time
```
[root@zabbix ~]# zabbix_get -s ???.???.???.??? -k pgsql.transactions.active[*]
 14.695067
```
Until this fix we need to put macros  {$PG_LONG_QUERY_THRESHOLD} up to value of 1800 (seconds) to get rid of alerts and didn't get alerts of real long queries

Regards
Regards