### PR TITLE
Fix transactions

### DIFF
--- a/files/postgresql/postgresql.conf
+++ b/files/postgresql/postgresql.conf
@@ -70,9 +70,9 @@ UserParameter=pgsql.streaming.lag.bytes[*],if [ "$(psql -qAtX $1 -c 'show server
 UserParameter=pgsql.streaming.lag.seconds[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "100000" ]; then psql -qAtX -h $2 $1 -c "SELECT CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0 ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()) END"; else psql -qAtX -h $2 $1 -c "SELECT CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0 ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()) END"; fi
 
 # Transactions
-UserParameter=pgsql.transactions.idle[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where state='idle in transaction'"
-UserParameter=pgsql.transactions.active[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where state <> 'idle in transaction' and state <> 'idle' and query NOT LIKE 'autovacuum: %'"
-UserParameter=pgsql.transactions.waiting[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "090600" ]; then psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where wait_event is not null"; else psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), query_start))), 0) from pg_stat_activity where waiting IS TRUE"; fi
+UserParameter=pgsql.transactions.idle[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), xact_start))), 0) from pg_stat_activity where state='idle in transaction'"
+UserParameter=pgsql.transactions.active[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), xact_start))), 0) from pg_stat_activity where state='active' and query NOT LIKE 'autovacuum:$
+UserParameter=pgsql.transactions.waiting[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "090600" ]; then psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), xact_start))), 0)$
 UserParameter=pgsql.transactions.prepared[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), prepared))), 0) from pg_prepared_xacts"
 
 # pg_stat_statements

--- a/files/postgresql/postgresql.conf
+++ b/files/postgresql/postgresql.conf
@@ -71,8 +71,8 @@ UserParameter=pgsql.streaming.lag.seconds[*],if [ "$(psql -qAtX $1 -c 'show serv
 
 # Transactions
 UserParameter=pgsql.transactions.idle[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), xact_start))), 0) from pg_stat_activity where state='idle in transaction'"
-UserParameter=pgsql.transactions.active[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), xact_start))), 0) from pg_stat_activity where state='active' and query NOT LIKE 'autovacuum:$
-UserParameter=pgsql.transactions.waiting[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "090600" ]; then psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), xact_start))), 0)$
+UserParameter=pgsql.transactions.active[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), xact_start))), 0) from pg_stat_activity where state='active' and query NOT LIKE 'autovacuum: %'"
+UserParameter=pgsql.transactions.waiting[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "090600" ]; then psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), xact_start))), 0) from pg_stat_activity where wait_event is not null"; else psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), xact_start))), 0) from pg_stat_activity where waiting IS TRUE"; fi
 UserParameter=pgsql.transactions.prepared[*],psql -qAtX $1 -c "select coalesce(extract(epoch from max(age(now(), prepared))), 0) from pg_prepared_xacts"
 
 # pg_stat_statements


### PR DESCRIPTION
- change field query_start to xact_start in transactions queries

reason:
xact_start - Time when this process' current transaction was started, or null if no transaction is active. If the current query is the first of its transaction, this column is equal to the query_start column.
query_start - Time when the currently active query was started, or if state is not active, when the last query was started

- find active transactions by name "active" as a state

