### PR TITLE
iostat: make compatible with iostat 11.6.1

### DIFF
--- a/files/iostat/scripts/iostat-collect.sh
+++ b/files/iostat/scripts/iostat-collect.sh
@@ -13,5 +13,5 @@ LC_ALL=C ; export LC_ALL
 
 [[ $# -lt 2 ]] && { echo "FATAL: some parameters not specified"; exit 1; }
 
-DISK=$($IOSTAT -xyd "$SECONDS" 1 | awk 'BEGIN {check=0;} {if(check==1 && $1!=""){print $0}if($1=="Device:"){check=1}}' | tr '\n' '|')
+DISK=$($IOSTAT -xyd "$SECONDS" 1 | awk 'BEGIN {check=0;} {if(check==1 && $1!=""){print $0}if($1~"^Device"){check=1}}' | tr '\n' '|')
 echo "$DISK" | sed 's/|/\n/g' > "$TOFILE"


### PR DESCRIPTION
The script expects a colon after Device. Make this optional.

I checked the script output to work with the mentioned version of iostat as well. Not checked the template.