### PR TITLE
PostgreSQL: ignore server version in config check

### DIFF
--- a/files/postgresql/postgresql.conf
+++ b/files/postgresql/postgresql.conf
@@ -80,7 +80,7 @@ UserParameter=pgsql.pgstatstatements.avg_query_time[*],psql -qAtX $1 -c "select 
 
 # Others
 UserParameter=pgsql.table.tuples[*],psql -qAtX $1 -c "select count(*) from $2"
-UserParameter=pgsql.config[*],psql -qAtX $1 -c "select json_build_object('extensions',(select array_agg(extname) from (select extname from pg_extension order by extname) as e),'settings', (select json_object(array_agg(name),array_agg(setting)) from (select name,setting from pg_settings where name != 'application_name' order by name) as s));"
+UserParameter=pgsql.config[*],psql -qAtX $1 -c "select json_build_object('extensions',(select array_agg(extname) from (select extname from pg_extension order by extname) as e),'settings', (select json_object(array_agg(name),array_agg(setting)) from (select name,setting from pg_settings where name != 'application_name' AND name != 'server_version' AND name != 'server_version_num' order by name) as s));"
 UserParameter=pgsql.trigger[*],psql -qAtX $1 -c "select count(*) from pg_trigger where tgenabled='O' and tgname='$2'"
 UserParameter=pgsql.wal.write[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "100000" ]; then psql -qAtX $1 -c "select pg_wal_lsn_diff(pg_current_wal_lsn(),'0/00000000')"; else psql -qAtX $1 -c "select pg_xlog_location_diff(pg_current_xlog_location(),'0/00000000')"; fi
 UserParameter=pgsql.wal.count[*],if [ "$(psql -qAtX $1 -c 'show server_version_num')" -ge "100000" ]; then psql -qAtX $1 -c "select count(*) from pg_ls_waldir()"; else psql -qAtX $1 -c "select count(*) from pg_ls_dir('pg_xlog')"; fi


### PR DESCRIPTION
configuration dump did include a version number. This was leading to a false positive alert of a changed config in case of minor version updates. This change ignores the version number when exporting the configuration.