### PR TITLE
iostat: Buffer iostat cron output and write at the end of sampling

### DIFF
--- a/files/iostat/crontab
+++ b/files/iostat/crontab
@@ -1,2 +1,2 @@
 # Collect data iops for zabbix - just execute "crontab -e" and write this line:
-* * * * * /usr/bin/iostat -ydt -o JSON 59 1 >/tmp/iostat-cron.out
+* * * * * DATA= $(/usr/bin/iostat -yxd -o JSON 59 1) ; echo $DATA >/tmp/iostat-cron.out


### PR DESCRIPTION
otherwise it would overwrite the output file at the beginning of the
sampling period which would not allow the zabbix agent to read
the data.

fixes #88